### PR TITLE
Basic policy finder class

### DIFF
--- a/lib/guarda/policy_finder.rb
+++ b/lib/guarda/policy_finder.rb
@@ -1,4 +1,29 @@
-class Guarda::PolicyFinder
-  def self.find(controller_name)
+module Guarda
+  class PolicyFinder
+    class NotFoundError < StandardError; end
+
+    def initialize(controller_name)
+      @controller_name = controller_name
+    end
+
+    def self.find(controller_name)
+      new(controller_name).find
+    end
+
+    def find
+      policy_class.presence || raise(NotFoundError, policy_class_name)
+    end
+
+    private
+
+    attr_reader :controller_name
+
+    def policy_class
+      policy_class_name.safe_constantize
+    end
+
+    def policy_class_name
+      controller_name.camelize.concat("Policy")
+    end
   end
 end

--- a/test/policy_finder_test.rb
+++ b/test/policy_finder_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class Guarda::PolicyFinderTest < ActiveSupport::TestCase
-  test "find" do
+  test ".find" do
     controller_name = "tests"
 
     policy_class = Guarda::PolicyFinder.find(controller_name)
@@ -9,10 +9,27 @@ class Guarda::PolicyFinderTest < ActiveSupport::TestCase
     assert_equal TestsPolicy, policy_class
   end
 
-    # controller_name "admin/tests"
-    # AdminTestsPolicy
+  test ".find with namespaced controller" do
+    controller_name = "admin/tests"
 
-  # not found
-  # controller_name = "prides"
-  # raises Guarda::PolicyNotFoundError
+    policy_class = Guarda::PolicyFinder.find(controller_name)
+
+    assert_equal Admin::TestsPolicy, policy_class
+  end
+
+  test ".find when policy cannot be found" do
+    controller_name = "nopolicy"
+
+    assert_raises Guarda::PolicyFinder::NotFoundError do
+      Guarda::PolicyFinder.find(controller_name)
+    end
+  end
+end
+
+class TestsPolicy
+end
+
+module Admin
+  class TestsPolicy
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,3 @@ require "active_support"
 require "minitest/reporters"
 
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
-
-class TestsPolicy
-end


### PR DESCRIPTION
Finds a policy class based on a given controller name.

"tests" => TestsPolicy
"admin/test" => Admin::TestsPolicy
"nopolicy" => raises Guarda::PolicyFinder::NotFoundError