### PR TITLE
Verify authorization performed

### DIFF
--- a/lib/guarda/authorization.rb
+++ b/lib/guarda/authorization.rb
@@ -3,8 +3,10 @@ module Guarda
     extend ActiveSupport::Concern
 
     class NotAuthorizedError < StandardError; end
+    class AuthorizationNotPerformedError < StandardError; end
 
     def authorize(controller: nil, query: nil, record: nil)
+      @_authorization_performed = true
       controller ||= controller_path
       query ||= "#{action_name}?"
 
@@ -14,6 +16,17 @@ module Guarda
 
     def policy(controller, record)
       PolicyFinder.find(controller).new(record)
+    end
+
+    def verify_authorization_performed
+      authorization_performed? ||
+        raise(AuthorizationNotPerformedError, self.class)
+    end
+
+    private
+
+    def authorization_performed?
+      !!@_authorization_performed
     end
   end
 end

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -41,4 +41,21 @@ class Guarda::AuthorizationTest < ActiveSupport::TestCase
       controller.authorize
     end
   end
+
+  test "#verify_authorization_performed when performed" do
+    controller = Controller.new(action_name: "index", controller_path: "tests")
+
+    assert_nothing_raised do
+      controller.authorize
+      controller.verify_authorization_performed
+    end
+  end
+
+  test "#verify_authorization_performed when not performed" do
+    controller = Controller.new(action_name: "index", controller_path: "tests")
+
+    assert_raises Guarda::Authorization::AuthorizationNotPerformedError do
+      controller.verify_authorization_performed
+    end
+  end
 end


### PR DESCRIPTION
allows errors to be raised if authorization hasn't been performed.