### PR TITLE
Update `authorize` signature

### DIFF
--- a/lib/guarda/authorization.rb
+++ b/lib/guarda/authorization.rb
@@ -10,7 +10,7 @@ module Guarda
       end
     end
 
-    def authorize(controller: nil, query: nil, record: nil)
+    def authorize(record = nil, controller: nil, query: nil)
       @_authorization_performed = true
       controller ||= controller_path
       query ||= "#{action_name}?"

--- a/lib/guarda/policy_finder.rb
+++ b/lib/guarda/policy_finder.rb
@@ -23,7 +23,7 @@ module Guarda
     end
 
     def policy_class_name
-      controller_name.camelize.concat("Policy")
+      controller_name.to_s.camelize.concat("Policy")
     end
   end
 end

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -21,11 +21,13 @@ class Guarda::AuthorizationTest < ActiveSupport::TestCase
   test "#authorize with optional attributes" do
     controller = Controller.new(action_name: "x", controller_path: "x")
 
-    assert controller.authorize(
-      controller: "tests",
-      query: "edit?",
-      record: Record.new
-    )
+    assert controller.authorize(Record.new, controller: "tests", query: "edit?")
+  end
+
+  test "#authorize with optional attributes as symbols" do
+    controller = Controller.new(action_name: "x", controller_path: "x")
+
+    assert controller.authorize(Record.new, controller: :tests, query: :edit?)
   end
 
   test "#authorize when policy is found but query is false" do


### PR DESCRIPTION
We want to be able to call `authorize(record)` without a keyword argument. Also want to support passing symbols instead of strings.